### PR TITLE
fix installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ More information can be found in our [blog post about optimsing Go tests paralle
 ## Installation
 
 ```bash
-go install -u github.com/roblaszczak/vgt
+go install github.com/roblaszczak/vgt@latest
 ```
 
 You can also run without installing by running `go run github.com/roblaszczak/vgt@latest`.


### PR DESCRIPTION
The PR fixes installation command in README.

Now, we have an error:
```sh
❯ go version
go version go1.23.2 darwin/arm64

❯ go install -u github.com/roblaszczak/vgt
flag provided but not defined: -u
usage: go install [build flags] [packages]
Run 'go help install' for details.
```

After:
```sh
❯ go install github.com/roblaszczak/vgt@latest
go: downloading github.com/roblaszczak/vgt v1.0.0
```