### PR TITLE
vgt: consider a skipped test to be passing

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -203,7 +203,7 @@ func Parse(scanner *bufio.Scanner) ParseResult {
 		case actionPass, actionFail, actionSkip:
 			testRuns.Update(tn, func(te TestExecution) TestExecution {
 				te.End = out.Time
-				te.Passed = out.Action == actionPass
+				te.Passed = out.Action != actionFail
 				return te
 			})
 		}


### PR DESCRIPTION
Oftentimes, tests will do some work and then skip the rest of the logic. In those cases, we should consider the test to be passing rather than failing when producing the graph.